### PR TITLE
Search attachment file names for #2987

### DIFF
--- a/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_GetEntriesForJournal_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_GetEntriesForJournal_Should.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Engraved.Core.Application.Persistence;
 using Engraved.Core.Domain.Entries;
+using Engraved.Core.Domain.Files;
 using Engraved.Core.Domain.Journals;
 using Engraved.Persistence.Mongo.Repositories;
 using Engraved.TestUtils;
@@ -201,6 +202,41 @@ public class UnrestrictedMongoRepository_GetEntriesForJournal_Should
     );
 
     entries.Length.Should().Be(1);
+  }
+
+  [Test]
+  public async Task Consider_AttachmentFileNames()
+  {
+    UpsertResult scrapsJournal = await _repository.UpsertJournal(new ScrapsJournal { Name = "My Scrap" });
+
+    await _repository.UpsertEntry(
+      new ScrapsEntry
+      {
+        ParentId = scrapsJournal.EntityId,
+        ScrapType = ScrapType.Markdown,
+        Title = "Nothing to match here",
+        Files =
+        [
+          new FileRef
+          {
+            Id = MongoUtil.GenerateNewIdAsString(),
+            FileName = "budget-2026.xlsx",
+            ContentType = "application/octet-stream",
+            ContentLength = 1234
+          }
+        ]
+      }
+    );
+
+    await AddScrap(scrapsJournal.EntityId, DateTime.Now, DateTime.Now);
+
+    var entries = await _repository.GetEntriesForJournal(
+      scrapsJournal.EntityId,
+      searchText: "budget"
+    );
+
+    entries.Length.Should().Be(1);
+    entries[0].Files[0].FileName.Should().Be("budget-2026.xlsx");
   }
 
   [Test]

--- a/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_SearchEntries_Should.cs
+++ b/api/Engraved.Persistence.Mongo.Tests/Source/UnrestrictedMongoRepository_SearchEntries_Should.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Engraved.Core.Application.Persistence;
 using Engraved.Core.Domain.Entries;
+using Engraved.Core.Domain.Files;
 using Engraved.Core.Domain.Journals;
 using Engraved.Core.Domain.Schedules;
 using Engraved.Persistence.Mongo.Repositories;
@@ -206,6 +208,69 @@ public class UnrestrictedMongoRepository_SearchEntries_Should
   }
 
   [Test]
+  public async Task Consider_AttachmentFileNames()
+  {
+    UpsertResult journal = await AddScrapWithAttachment("budget-2026.xlsx");
+
+    var results = await _repository.SearchEntries("budget", null, null, [journal.EntityId], 10);
+
+    results.Length.Should().Be(1);
+    results[0].Files[0].FileName.Should().Be("budget-2026.xlsx");
+  }
+
+  [Test]
+  public async Task Consider_AttachmentFileNames_OfAnyAttachedFile()
+  {
+    // A dotted path into an array of sub-documents matches when ANY element matches, so the
+    // second attachment must be found just as well as the first.
+    UpsertResult journal = await AddScrapWithAttachment("first.pdf", "second.pdf");
+
+    var results = await _repository.SearchEntries("second", null, null, [journal.EntityId], 10);
+
+    results.Length.Should().Be(1);
+  }
+
+  [Test]
+  public async Task Not_Consider_AttachmentFileNames_When_OnlyConsideringTitle()
+  {
+    // The title-only search exists to be narrow; folding attachments into it would defeat that.
+    UpsertResult journal = await AddScrapWithAttachment("budget-2026.xlsx");
+
+    var results = await _repository.SearchEntries(
+      "budget",
+      null,
+      null,
+      [journal.EntityId],
+      10,
+      null,
+      true
+    );
+
+    results.Should().BeEmpty();
+  }
+
+  [Test]
+  public async Task Not_Consider_AttachmentFileNames_When_MatchingAnyWord()
+  {
+    // Match-any-word collects candidates for "related items", which ranks them on title and notes
+    // alone - an entry matched purely by a file name would score zero there.
+    UpsertResult journal = await AddScrapWithAttachment("budget-2026.xlsx");
+
+    var results = await _repository.SearchEntries(
+      "budget",
+      null,
+      null,
+      [journal.EntityId],
+      10,
+      null,
+      false,
+      true
+    );
+
+    results.Should().BeEmpty();
+  }
+
+  [Test]
   public async Task Consider_JournalTypes_Negative()
   {
     var results = await _repository.SearchEntries(
@@ -374,6 +439,32 @@ public class UnrestrictedMongoRepository_SearchEntries_Should
     results.Length.Should().Be(2);
     ((ScrapsEntry)results[0]).Title.Should().Be("RecentUnscheduled");
     ((ScrapsEntry)results[1]).Title.Should().Be("OldButScheduled");
+  }
+
+  private async Task<UpsertResult> AddScrapWithAttachment(params string[] fileNames)
+  {
+    UpsertResult journal = await _repository.UpsertJournal(new ScrapsJournal { Name = "With Files" });
+
+    await _repository.UpsertEntry(
+      new ScrapsEntry
+      {
+        ParentId = journal.EntityId,
+        ScrapType = ScrapType.Markdown,
+        Title = "Nothing to match here",
+        Files = fileNames
+          .Select(fileName => new FileRef
+            {
+              Id = MongoUtil.GenerateNewIdAsString(),
+              FileName = fileName,
+              ContentType = "application/octet-stream",
+              ContentLength = 1234
+            }
+          )
+          .ToArray()
+      }
+    );
+
+    return journal;
   }
 
   [Test]

--- a/api/Engraved.Persistence.Mongo/Source/FreeTextFilters.cs
+++ b/api/Engraved.Persistence.Mongo/Source/FreeTextFilters.cs
@@ -20,6 +20,22 @@ public static class FreeTextFilters
     params Expression<Func<T, object>>[] fieldNameExpressions
   ) where T : IDocument
   {
+    return Build(
+      searchText,
+      matchAnyWord,
+      fieldNameExpressions.Select(FieldDefinition<T> (e) => new ExpressionFieldDefinition<T>(e)).ToArray()
+    );
+  }
+
+  // Same as above, for callers that need a field a lambda cannot express: a field inside an array of
+  // sub-documents ("Files.FileName", which mongo matches when ANY element matches) can only be
+  // written as a string path - the driver turns an expression into an indexed path instead.
+  public static List<FilterDefinition<T>> Build<T>(
+    string? searchText,
+    bool matchAnyWord,
+    params FieldDefinition<T>[] fields
+  ) where T : IDocument
+  {
     if (string.IsNullOrEmpty(searchText))
     {
       return [];
@@ -36,8 +52,8 @@ public static class FreeTextFilters
             : Regex.Escape(segment);
 
           return Builders<T>.Filter.Or(
-            fieldNameExpressions.Select(exp => Builders<T>.Filter.Regex(
-                exp,
+            fields.Select(field => Builders<T>.Filter.Regex(
+                field,
                 new BsonRegularExpression(
                   new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Multiline)
                 )

--- a/api/Engraved.Persistence.Mongo/Source/Repositories/MongoEntryRepository.cs
+++ b/api/Engraved.Persistence.Mongo/Source/Repositories/MongoEntryRepository.cs
@@ -43,11 +43,10 @@ public class MongoEntryRepository(MongoDatabaseClient mongoDatabaseClient, Mongo
     if (!string.IsNullOrEmpty(searchText))
     {
       filters.AddRange(
-        FreeTextFilters.Build<EntryDocument>(
+        FreeTextFilters.Build(
           searchText,
           false,
-          d => d.Notes!,
-          d => ((ScrapsEntryDocument) d).Title!
+          GetFreeTextFields(onlyConsiderTitle: false, includeFileNames: true)
         )
       );
     }
@@ -106,12 +105,10 @@ public class MongoEntryRepository(MongoDatabaseClient mongoDatabaseClient, Mongo
     if (!string.IsNullOrEmpty(searchText))
     {
       filters.AddRange(
-        FreeTextFilters.Build<EntryDocument>(
+        FreeTextFilters.Build(
           searchText,
           matchAnyWord,
-          onlyConsiderTitle
-            ? [d => ((ScrapsEntryDocument) d).Title!]
-            : [d => ((ScrapsEntryDocument) d).Title!, d => d.Notes!]
+          GetFreeTextFields(onlyConsiderTitle, includeFileNames: !matchAnyWord)
         )
       );
     }
@@ -320,6 +317,33 @@ public class MongoEntryRepository(MongoDatabaseClient mongoDatabaseClient, Mongo
     );
 
     return entries;
+  }
+
+  // Attachment file names are searched alongside the text, so that a scrap can be found by what is
+  // attached to it. Two searches deliberately leave them out: the title-only search exists to be
+  // narrow, and the match-any-word search collects candidates for "related items", which ranks them
+  // on title and notes alone - an entry matched purely by a file name would score zero there.
+  private static FieldDefinition<EntryDocument>[] GetFreeTextFields(bool onlyConsiderTitle, bool includeFileNames)
+  {
+    FieldDefinition<EntryDocument> title = Field(d => ((ScrapsEntryDocument) d).Title!);
+
+    if (onlyConsiderTitle)
+    {
+      return [title];
+    }
+
+    FieldDefinition<EntryDocument> notes = Field(d => d.Notes!);
+
+    return includeFileNames
+      ? [title, notes, new StringFieldDefinition<EntryDocument>("Files.FileName")]
+      : [title, notes];
+  }
+
+  // ExpressionFieldDefinition takes an untyped LambdaExpression, so an inlined lambda has no
+  // inferable delegate type - this gives it one.
+  private static FieldDefinition<EntryDocument> Field(Expression<Func<EntryDocument, object>> expression)
+  {
+    return new ExpressionFieldDefinition<EntryDocument>(expression);
   }
 
   private static FilterDefinition<EntryDocument> GetHasScheduleForCurrentUserFilter(string currentUserId)


### PR DESCRIPTION
Follow-up to #2987, from the ideas raised after testing increment 3: an entry can now be found by the name of a file attached to it. Free-text search matches `Files.FileName` alongside the notes and the title, both in the global search and when searching within a journal.

Backend only. The search box already sends plain text, and scrap results already render their file chips.

## Two searches deliberately do not match file names

**The title-only search** exists to be narrow. Folding attachments into it would defeat the point of having it.

**The match-any-word search** is the candidate query behind "related items", which ranks candidates on title and notes alone. An entry matched purely by a file name would score zero, contradicting the invariant `GetRelatedEntitiesQueryExecutor` states in its own comment - that every candidate scores at least 1. Filename overlap is weak evidence of relatedness anyway.

Both exclusions are pinned by tests. Neither is vacuous: removing the gate was confirmed to make both fail, which mattered here because a whole-word pattern that happened not to match `budget-2026.xlsx` would have let one of them pass for the wrong reason.

## The overload

`FreeTextFilters.Build` took `Expression<Func<T, object>>[]`, and a field inside an array of sub-documents has no expression form - the driver renders an indexed path rather than the any-element path mongo needs. `Build` therefore gained an overload taking `FieldDefinition<T>[]`; the expression overload delegates to it, so the two journal call sites are untouched.

## Worth knowing

- This is regex matching, so it scans rather than uses an index, and it adds a third field to the OR. Same cost shape as the existing notes and title search rather than a new one, but it is RU on the free tier.
- Non-scrap entries are included in the filter too. Only scraps can currently receive attachments, so nothing extra matches today; it costs nothing and will not need revisiting if that changes.
- In compact display mode `ScrapBody` hides the body and the chips, so a filename-only match shows no visible reason for being in the results. That is pre-existing behaviour which applies equally to notes matches, so it is left alone here.

## Testing

5 new tests against real mongo; full backend suite 347 passing, build clean with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
