### PR TITLE
Drop trailing empty paragraphs when rendering markdown

### DIFF
--- a/app/src/components/details/scraps/markdown/LazyMarkdown.test.tsx
+++ b/app/src/components/details/scraps/markdown/LazyMarkdown.test.tsx
@@ -165,4 +165,53 @@ describe("LazyMarkdown", () => {
     expect(items[0].textContent).toBe("one");
     expect(items[1].textContent).toBe("two");
   });
+
+  // The editor's document always ends in a block, so the only way out of a list is
+  // Enter on an empty item - which leaves an empty paragraph behind that the editor
+  // serializes as a trailing "\n\n". Rendering it would add an empty line between
+  // the content and the entry footer.
+  it("drops a trailing empty paragraph after a list", () => {
+    const { container } = render(<LazyMarkdown value={"- one\n- two\n\n"} />);
+
+    expect(container.querySelectorAll("li")).toHaveLength(2);
+    expect(container.querySelectorAll("p")).toHaveLength(0);
+    expect(container.innerHTML).not.toContain("&nbsp;");
+  });
+
+  it("drops a trailing empty paragraph after a plain paragraph", () => {
+    const { container } = render(<LazyMarkdown value={"Paragraph 1\n\n"} />);
+
+    const paragraphs = container.querySelectorAll("p");
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraphs[0].textContent).toBe("Paragraph 1");
+    expect(container.innerHTML).not.toContain("&nbsp;");
+  });
+
+  it("drops several trailing empty paragraphs", () => {
+    const { container } = render(
+      <LazyMarkdown value={"- one\n\n\n\n&nbsp;\n\n \n\n"} />,
+    );
+
+    expect(container.querySelectorAll("li")).toHaveLength(1);
+    expect(container.querySelectorAll("p")).toHaveLength(0);
+    expect(container.innerHTML).not.toContain("&nbsp;");
+  });
+
+  it("keeps empty paragraphs that are between content", () => {
+    const { container } = render(
+      <LazyMarkdown value={"- one\n\n\n\nafter\n\n"} />,
+    );
+
+    const paragraphs = container.querySelectorAll("p");
+    expect(container.querySelectorAll("li")).toHaveLength(1);
+    expect(paragraphs).toHaveLength(2);
+    expect(paragraphs[0].innerHTML).toBe("&nbsp;");
+    expect(paragraphs[1].textContent).toBe("after");
+  });
+
+  it("renders nothing for markdown that is only blank lines", () => {
+    const { container } = render(<LazyMarkdown value={"\n\n&nbsp;\n\n"} />);
+
+    expect(container.querySelectorAll("p")).toHaveLength(0);
+  });
 });

--- a/app/src/components/details/scraps/markdown/LazyMarkdown.tsx
+++ b/app/src/components/details/scraps/markdown/LazyMarkdown.tsx
@@ -88,16 +88,29 @@ function getHtml(value: string, useBasic?: boolean) {
 // blocks are handed to marked as usual, so multi-line constructs (lists, hard
 // breaks, ...) - which use single newlines internally - keep rendering correctly.
 function parseBlocks(value: string): string {
-  return value
+  const blocks = value
     .replace(/^[^\S\n]+$/gm, "") // treat whitespace-only lines as empty lines
-    .split(/\n\n/)
-    .map((block) => {
-      const trimmed = block.trim();
-      return trimmed === "" || trimmed === "&nbsp;"
-        ? "<p>&nbsp;</p>"
-        : md.parse(block).toString();
-    })
+    .split(/\n\n/);
+
+  // Blank lines between content are the spacing the user added, but blank lines
+  // after it are not: the editor's document always ends in a block, so leaving a
+  // list (Enter on an empty item) drops the caret into an empty paragraph that is
+  // then serialized along with the rest. Rendering that would put an empty line
+  // between the content and whatever follows it - the entry footer, usually.
+  while (blocks.length && isEmptyBlock(blocks[blocks.length - 1])) {
+    blocks.pop();
+  }
+
+  return blocks
+    .map((block) =>
+      isEmptyBlock(block) ? "<p>&nbsp;</p>" : md.parse(block).toString(),
+    )
     .join("");
+}
+
+function isEmptyBlock(block: string): boolean {
+  const trimmed = block.trim();
+  return trimmed === "" || trimmed === "&nbsp;";
 }
 
 export default LazyMarkdown;


### PR DESCRIPTION
## What

`parseBlocks` in `LazyMarkdown.tsx` now drops empty blocks at the end of the markdown before rendering. Empty blocks *between* content are still rendered as `<p>&nbsp;</p>`, unchanged.

## Why

A scrap ending in a list rendered an extra `<p>&nbsp;</p>`, which showed up as too much whitespace between the list and the entry footer.

The cause isn't the list itself, it's the empty paragraph after it. The editor's document always ends in a block, so the only way out of a list is Enter on an empty item — which lifts the caret into a fresh empty paragraph that gets serialized along with the rest. Confirmed against the actual tiptap serializer:

```
"<ul><li>one</li></ul><p></p>"  =>  "- one\n\n"
"<p>text</p><p></p>"            =>  "text\n\n"
```

`parseBlocks` splits on `\n\n`, gets `["- one", ""]`, and renders the trailing empty block as a visible empty paragraph — the same code that deliberately preserves blank lines the user added between paragraphs.

## Reviewer notes

- **Not list-specific.** Anything ending in an empty paragraph (`"text\n\n"`) is trimmed too. That is intentional: blank lines between content are spacing the user added, blank lines after it are not. A list is just the case where the trailing paragraph is unavoidable.
- **Rendering rather than editor, on purpose.** Trimming in the editor's `onUpdate` would only help content that gets re-edited and re-saved; every scrap already stored with a trailing paragraph would stay broken. The rendering fix is retroactive. It also keeps the stored markdown a faithful round-trip of the editor document — the caret really is in a paragraph below the list.
- No data migration, no API change; frontend only.

## Testing

Five cases added to `LazyMarkdown.test.tsx`: trailing empty paragraph after a list, after a plain paragraph, several trailing ones (`"- one\n\n\n\n&nbsp;\n\n \n\n"`), blank lines between content still preserved, and markdown that is only blank lines rendering to nothing.

158 tests pass across all 21 files; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
