### PR TITLE
Report why applying a new version failed

### DIFF
--- a/app/src/VersionChecker.tsx
+++ b/app/src/VersionChecker.tsx
@@ -5,9 +5,12 @@ import { useQuery } from "@tanstack/react-query";
 import { queryKeysFactory } from "./serverApi/reactQuery/queryKeysFactory";
 import { ActionFactory } from "./components/common/actions/ActionFactory";
 import { FadeInContainer } from "./components/common/FadeInContainer";
+import { useAppContext } from "./AppContext";
 
 export const VersionChecker: React.FC = () => {
   const isNewVersionAvailable = useIsNewVersionAvailableQuery();
+
+  const { setAppAlert } = useAppContext();
 
   if (!isNewVersionAvailable) {
     return null;
@@ -15,7 +18,9 @@ export const VersionChecker: React.FC = () => {
 
   return (
     <FadeInContainer doPulsate={true}>
-      <ActionIconButton action={ActionFactory.updateToNewVersion()} />
+      <ActionIconButton
+        action={ActionFactory.updateToNewVersion(setAppAlert)}
+      />
     </FadeInContainer>
   );
 };

--- a/app/src/components/common/LazyLoadSuspender.tsx
+++ b/app/src/components/common/LazyLoadSuspender.tsx
@@ -43,9 +43,13 @@ class LazyLoadErrorBoundaryClass extends React.Component<
 const ErrorOnLazyLoad: React.FC = () => {
   const [isOpen, setIsOpen] = useState(true);
 
+  // This dialog is rendered above AppContextProvider (see App.tsx), so a failed
+  // update cannot go through the usual app alert and is shown right here.
+  const [failure, setFailure] = useState("");
+
   return (
     <Dialog open={isOpen} onClose={() => setIsOpen(false)}>
-      <Host onClick={() => void applyNewVersion()}>
+      <Host onClick={() => void applyNewVersion(setFailure)}>
         <SwitchAccessShortcutOutlined
           sx={{ color: "primary.main" }}
           fontSize={"large"}
@@ -53,6 +57,9 @@ const ErrorOnLazyLoad: React.FC = () => {
         <Typography sx={{ pt: 2, color: "primary.main" }}>
           Update available, click to reload.
         </Typography>
+        {failure ? (
+          <Typography sx={{ pt: 2, color: "error.main" }}>{failure}</Typography>
+        ) : null}
       </Host>
     </Dialog>
   );

--- a/app/src/components/common/actions/ActionFactory.tsx
+++ b/app/src/components/common/actions/ActionFactory.tsx
@@ -436,12 +436,21 @@ export class ActionFactory {
     };
   }
 
-  static updateToNewVersion(): IAction {
+  static updateToNewVersion(
+    setAppAlert: (appAlert: IAppAlert | null) => void,
+  ): IAction {
     const color = "#fdff00";
 
     return {
       icon: <SwitchAccessShortcutOutlined fontSize="small" />,
-      onClick: () => void applyNewVersion(),
+      onClick: () =>
+        void applyNewVersion((message) =>
+          setAppAlert({
+            type: "error",
+            title: "Update failed",
+            message: message,
+          }),
+        ),
       label: "New version available - click to update.",
       key: "update-to-new-version",
       sx: {

--- a/app/src/serviceWorkerUpdater.ts
+++ b/app/src/serviceWorkerUpdater.ts
@@ -38,11 +38,25 @@ const updateServiceWorker = registerSW({
 });
 
 /**
+ * Called when an update the user asked for did not happen. The message is meant
+ * to be shown to them, so it says what to do about it rather than what broke.
+ */
+export type UpdateFailedHandler = (message: string) => void;
+
+// A worker that fetches imports while installing - ours pulls the OneSignal SDK
+// from a CDN, see vite.config.js - can be slow on a bad connection, but not this
+// slow. Past this we report instead of leaving the button looking dead.
+const installTimeoutMs = 30_000;
+
+/**
  * Update the app to the freshly deployed version and reload once the new
  * service worker controls the page. Safe to call even when service workers are
- * unavailable (falls back to a plain reload).
+ * unavailable (falls back to a plain reload). Reports through `onFailed` when
+ * the update cannot be completed, so that the caller can tell the user.
  */
-export async function applyNewVersion(): Promise<void> {
+export async function applyNewVersion(
+  onFailed?: UpdateFailedHandler,
+): Promise<void> {
   userRequestedUpdate = true;
 
   const registration = swRegistration;
@@ -69,9 +83,80 @@ export async function applyNewVersion(): Promise<void> {
     console.warn("Service worker update check failed.", error);
   }
 
-  // Fallback: if no new worker materialised (already up to date locally, or the
-  // update check failed), reload so the user is never stuck on the button.
-  if (!registration.waiting && !registration.installing) {
-    location.reload();
+  // update() resolves once the check is done, which is normally well before the
+  // worker it found has finished installing. Waiting for that here is what keeps
+  // the button from silently doing nothing: an install that fails - a throwing
+  // importScripts takes the worker straight to "redundant" - means onNeedRefresh
+  // never fires, and without this nothing would happen and nothing be reported.
+  if (registration.installing) {
+    await waitForInstall(registration.installing, onFailed);
+    return;
   }
+
+  // Installed while we were waiting on update() - activate it + reload.
+  if (registration.waiting) {
+    await updateServiceWorker(true);
+    return;
+  }
+
+  // Nothing new to install: we already run the newest worker the server offers,
+  // so a plain reload is both correct here and all we can do.
+  location.reload();
+}
+
+// Resolves once the worker has installed (onNeedRefresh then finishes the
+// update), and reports through onFailed when it dies or takes too long instead.
+function waitForInstall(
+  worker: ServiceWorker,
+  onFailed?: UpdateFailedHandler,
+): Promise<void> {
+  return new Promise((resolve) => {
+    const timeout = window.setTimeout(
+      () =>
+        finish(
+          "The new version is taking too long to install. Please try again.",
+        ),
+      installTimeoutMs,
+    );
+
+    function finish(failure?: string) {
+      window.clearTimeout(timeout);
+      worker.removeEventListener("statechange", checkState);
+
+      if (failure) {
+        console.error(
+          `Service worker update failed (state "${worker.state}").`,
+          failure,
+        );
+        onFailed?.(failure);
+      }
+
+      resolve();
+    }
+
+    function checkState() {
+      switch (worker.state) {
+        // "installed" means it is waiting to activate: onNeedRefresh has fired
+        // by now and, because the user asked for this, already triggered the
+        // skipWaiting + reload. "activated" means that is under way.
+        case "installed":
+        case "activated":
+          finish();
+          break;
+
+        // The install failed. A throwing importScripts is how that happens here.
+        case "redundant":
+          finish(
+            "The new version could not be installed - it probably could not be downloaded. Please check your connection and try again.",
+          );
+          break;
+      }
+    }
+
+    worker.addEventListener("statechange", checkState);
+
+    // The worker can have moved on between us reading registration.installing
+    // and subscribing here, in which case no further statechange is coming.
+    checkState();
+  });
 }


### PR DESCRIPTION
## What

`applyNewVersion` now waits for an installing service worker instead of returning silently, and reports through a new optional `onFailed` handler when the install dies or stalls.

## Why

On Android the "new version available" button did nothing — no reload, no error, nothing in the console.

The hole is in [`applyNewVersion`](https://github.com/PzYon/engraved/blob/main/app/src/serviceWorkerUpdater.ts):

```js
if (!registration.waiting && !registration.installing) {
  location.reload();
}
```

If `registration.update()` leaves a worker in `installing`, neither branch runs and the function returns having done nothing at all. Completing the update is then entirely up to `onNeedRefresh` firing later — and it never fires if the install fails.

That is a real possibility here, because the generated worker does an unguarded top-level `importScripts` of the OneSignal SDK from `cdn.onesignal.com` (`vite.config.js:45`). Workbox's `generateSW` template emits it bare, with no try/catch and no option to add one. If that cross-origin fetch fails the worker goes straight to `redundant` — far likelier on mobile (flaky network, DNS-level ad blockers, data saver) than on desktop, which matches the symptom being Android-only.

## What changed

- `waitForInstall` subscribes to `statechange` on the installing worker: resolves on `installed`/`activated` (where `onNeedRefresh` takes over), reports on `redundant`, reports on a 30s timeout. It also calls the check once immediately after subscribing, since the worker can move on between reading `registration.installing` and attaching the listener — no further event would arrive.
- The old combined fallback is split into two explicit branches: activate if a worker installed while we awaited `update()`, otherwise reload because there genuinely is nothing new.
- `ActionFactory.updateToNewVersion(setAppAlert)` surfaces the message as an error alert; `VersionChecker` passes `setAppAlert` from context.
- `LazyLoadSuspender`'s dialog uses local state and renders the message inline instead — it sits at `App.tsx:60`, above `AppContextProvider` (line 210), so `useAppContext` is not available there.
- Every failure path also `console.error`s with the worker's state, so `chrome://inspect` has the detail behind the generic user-facing message.

## Reviewer notes

- **This does not fix a failing update — it makes one say so.** That is the point: the next Android occurrence should report either "could not be installed" (→ the CDN import is the cause) or "taking too long" (→ it stalls rather than fails), which decides whether the follow-up is self-hosting the OneSignal worker or moving to `injectManifest` so the import can be wrapped in a try/catch.
- **No tests.** Driving the SW lifecycle under jsdom would mean turning `src/test/virtualPwaRegisterStub.ts` into a harness that captures the `registerSW` callbacks and faking a `ServiceWorker` with mutable `state` — a larger change than the fix itself. This path is verified by reading only; worth knowing when reviewing.
- The 30s timeout is a judgement call, chosen to be well clear of a slow mobile install without leaving the button looking dead.

## Testing

`tsc --noEmit` clean, eslint clean, 158 tests pass across 21 files (all pre-existing — nothing here is covered by them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
